### PR TITLE
feat(web): first-time profile setup flow for new users

### DIFF
--- a/coach/web/chainlit_app.py
+++ b/coach/web/chainlit_app.py
@@ -48,6 +48,8 @@ _SESSION_CURRENT_SECTION = 'current_section'
 _SESSION_CURRENT_PROFILE = 'current_profile'
 _SESSION_ACTIVITIES = 'activities'
 _SESSION_DISPLAY_NAME = 'display_name'
+_SESSION_SECTIONS_QUEUE = 'sections_queue'
+_SESSION_IS_SETUP_MODE = 'is_setup_mode'
 
 _MODE_COACH = 'coach'
 _MODE_PROFILE = 'profile'
@@ -105,6 +107,10 @@ async def on_chat_start() -> None:
     cl.user_session.set(_SESSION_ACTIVITIES, activities)
     cl.user_session.set(_SESSION_CURRENT_PROFILE, profile)
 
+    if profile is None:
+        await _prompt_profile_setup(display_name).send()
+        return
+
     _init_coach_session(profile, activities, display_name)
     await cl.Message(f'Hello, {display_name}. Coach is ready. What would you like to work on today?').send()
 
@@ -158,10 +164,19 @@ async def _complete_current_section() -> None:
 
     await cl.Message(f'✓ {current_section.title()} saved.').send()
 
-    activities: list[Activity] = cl.user_session.get(_SESSION_ACTIVITIES)
-    display_name: str = cl.user_session.get(_SESSION_DISPLAY_NAME)
-    _init_coach_session(updated_profile, activities, display_name)
-    await cl.Message('Profile updated — coach restarted with your latest profile.').send()
+    sections_queue: list[ProfileParts] = cl.user_session.get(_SESSION_SECTIONS_QUEUE, default=[])
+    if sections_queue:
+        await _enter_next_section()
+    else:
+        activities: list[Activity] = cl.user_session.get(_SESSION_ACTIVITIES)
+        display_name: str = cl.user_session.get(_SESSION_DISPLAY_NAME)
+        _init_coach_session(updated_profile, activities, display_name)
+        is_setup: bool = cl.user_session.get(_SESSION_IS_SETUP_MODE, default=False)
+        if is_setup:
+            cl.user_session.set(_SESSION_IS_SETUP_MODE, False)
+            await cl.Message('Profile setup complete! Coach is ready. What would you like to work on today?').send()
+        else:
+            await cl.Message('Profile updated — coach restarted with your latest profile.').send()
 
 
 def _init_coach_session(profile: Optional[UserProfile], activities: list[Activity], display_name: str) -> None:
@@ -176,6 +191,84 @@ def _is_done(response: str) -> bool:
 
 def _strip_done(response: str) -> str:
     return re.sub(r'(?i)\bDONE[.!]?\s*$', '', response).strip()
+
+
+def _setup_progress_message(section: ProfileParts, position: int, total: int) -> str:
+    return f'Section {position} of {total}: {section.title()}'
+
+
+def _prompt_profile_setup(display_name: str) -> cl.Message:
+    actions = [
+        cl.Action(name='start_profile_setup', payload={}, label='Set up profile'),
+        cl.Action(name='skip_to_coaching', payload={}, label='Skip — go straight to coaching'),
+    ]
+    return cl.Message(
+        f"Welcome, {display_name}! Before we start, let's set up your profile so I can give you tailored guidance. "
+        'This involves 5 short sections (chat preferences, training, background, constraints, and goals). '
+        'You can skip any section.',
+        actions=actions,
+    )
+
+
+@cl.action_callback('start_profile_setup')
+async def on_start_profile_setup(action: cl.Action) -> None:
+    sections_queue = list(ProfileParts)
+    profile_assistant = ProfileAssistant(provider=LLMProvider.GOOGLE, model=None)
+    collected: dict[ProfileParts, Optional[str]] = {}
+
+    cl.user_session.set(_SESSION_PROFILE_ASSISTANT, profile_assistant)
+    cl.user_session.set(_SESSION_COLLECTED_SECTIONS, collected)
+    cl.user_session.set(_SESSION_SECTIONS_QUEUE, sections_queue)
+    cl.user_session.set(_SESSION_IS_SETUP_MODE, True)
+
+    await _enter_next_section()
+
+
+@cl.action_callback('skip_to_coaching')
+async def on_skip_to_coaching(action: cl.Action) -> None:
+    activities: list[Activity] = cl.user_session.get(_SESSION_ACTIVITIES)
+    display_name: str = cl.user_session.get(_SESSION_DISPLAY_NAME)
+    _init_coach_session(None, activities, display_name)
+    await cl.Message('No problem! Coach is ready. What would you like to work on today?').send()
+
+
+@cl.action_callback('skip_section')
+async def on_skip_section(action: cl.Action) -> None:
+    current_section: ProfileParts = cl.user_session.get(_SESSION_CURRENT_SECTION)
+    collected: dict[ProfileParts, Optional[str]] = cl.user_session.get(_SESSION_COLLECTED_SECTIONS)
+    collected[current_section] = None
+    cl.user_session.set(_SESSION_COLLECTED_SECTIONS, collected)
+    await cl.Message(f'Skipped {current_section.title()}.').send()
+
+    sections_queue: list[ProfileParts] = cl.user_session.get(_SESSION_SECTIONS_QUEUE) or []
+    if sections_queue:
+        await _enter_next_section()
+    else:
+        activities: list[Activity] = cl.user_session.get(_SESSION_ACTIVITIES)
+        display_name: str = cl.user_session.get(_SESSION_DISPLAY_NAME)
+        current_profile: Optional[UserProfile] = cl.user_session.get(_SESSION_CURRENT_PROFILE)
+        _init_coach_session(current_profile, activities, display_name)
+        cl.user_session.set(_SESSION_IS_SETUP_MODE, False)
+        await cl.Message('Profile setup complete! Coach is ready. What would you like to work on today?').send()
+
+
+async def _enter_next_section() -> None:
+    sections_queue: list[ProfileParts] = cl.user_session.get(_SESSION_SECTIONS_QUEUE)
+    section = sections_queue.pop(0)
+    cl.user_session.set(_SESSION_SECTIONS_QUEUE, sections_queue)
+    cl.user_session.set(_SESSION_CURRENT_SECTION, section)
+
+    profile_assistant: ProfileAssistant = cl.user_session.get(_SESSION_PROFILE_ASSISTANT)
+    collected: dict[ProfileParts, Optional[str]] = cl.user_session.get(_SESSION_COLLECTED_SECTIONS)
+    intro = profile_assistant.start_section(section, collected)
+
+    total = len(ProfileParts)
+    position = total - len(sections_queue)
+    progress = _setup_progress_message(section, position, total)
+
+    actions = [cl.Action(name='skip_section', payload={}, label='Skip this section')]
+    cl.user_session.set(_SESSION_MODE, _MODE_PROFILE)
+    await cl.Message(f'{progress}\n\n{intro}', actions=actions).send()
 
 
 def _connect_strava_user_prompt() -> cl.Message:

--- a/coach/web/tests/test_chainlit_app.py
+++ b/coach/web/tests/test_chainlit_app.py
@@ -4,9 +4,11 @@ from unittest.mock import patch
 from coach.persistence.repositories.activities import SupabaseActivityRepository
 from coach.persistence.repositories.profiles import SupabaseUserProfileRepository
 from coach.persistence.repositories.users import SupabaseUsersRepository
+from coach.reasoning.profile_assistant.system_prompts import ProfileParts
 from coach.web.chainlit_app import _get_display_name
 from coach.web.chainlit_app import _is_done
 from coach.web.chainlit_app import _load_coaching_data
+from coach.web.chainlit_app import _setup_progress_message
 from coach.web.chainlit_app import _strip_done
 
 
@@ -91,3 +93,14 @@ class TestLoadCoachingData:
 
     def test_returns_activities_from_repo(self) -> None:
         assert self._activities is self._mock_activity_repo.list_all.return_value
+
+
+class TestSetupProgressMessage:
+    def test_first_section(self) -> None:
+        assert _setup_progress_message(ProfileParts.CHAT_PREFERENCES, 1, 5) == 'Section 1 of 5: Chat Preferences'
+
+    def test_middle_section(self) -> None:
+        assert _setup_progress_message(ProfileParts.TRAINING_PREFERENCES, 2, 5) == 'Section 2 of 5: Training Preferences'
+
+    def test_last_section(self) -> None:
+        assert _setup_progress_message(ProfileParts.GOALS, 5, 5) == 'Section 5 of 5: Goals'


### PR DESCRIPTION
## Summary

- `on_chat_start` branches on `profile is None`: shows a welcome message with **Set up profile** and **Skip — go straight to coaching** action buttons instead of directly initialising Coach
- **Set up**: builds a `sections_queue` of all 5 `ProfileParts`, creates `ProfileAssistant`, calls `_enter_next_section()` which pops the first section, sends its intro + Skip button with a progress indicator (`Section N of 5: <Name>`)
- After each section DONE, `_complete_current_section` advances to the next queued section or, when the queue is exhausted, inits Coach and sends a completion message
- **Skip button** per section: records `None` for that section and advances identically to DONE
- **Skip entire setup**: inits Coach with `profile=None` immediately
- `_setup_progress_message()` extracted as a plain testable helper

## Test plan

- [ ] `TestSetupProgressMessage` — 3 tests: first, middle, last section
- [ ] Full suite: 179 passed

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)