### PR TITLE
fix: verify Strava webhook HMAC-SHA256 signature

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -17,12 +17,15 @@ Live at https://coach-production-e0b4.up.railway.app/ (Railway, Dockerfile-based
 
 Layer flow:
 1. `coach/web/chainlit_app.py` — thin Chainlit wiring only; delegates everything to session/coaching/profile_flow
+   └ mounts `coach/web/app.py` (FastAPI) at `/oauth` for Strava OAuth callback + webhook events
 2. `coach/web/session.py` — auth helpers + session key constants
 3. `coach/web/coaching.py` — coach session init, data loading, LLM config; owns `SESSION_*`/`MODE_*` constants
 4. `coach/web/profile_flow.py` — profile setup/editing flow
 5. `coach/builders/` — `Activity` → `RecentTrainingHistory`, `RunningPersonalBestsSummary`, `TrainingGoal`
 6. `coach/reasoning/` — `Coach`/`ProfileAssistant`; `providers.py` for LLM key resolution; `clients.py` for LLM wrappers
 7. `coach/persistence/` — Supabase repos; Vault RPC via `SUPABASE_SECRET_KEY` for Strava tokens + API keys
+   FastAPI routers: `strava_oauth.py` (OAuth callback), `strava_webhook.py` (activity + deauth events)
+   Deauthorization service: `coach/ingestion/strava/deauthorize.py`
 
 ## Skills
 
@@ -36,4 +39,4 @@ Use these slash commands for task-specific guidance:
 
 ## Roadmap
 
-See `.claude/docs/roadmap.md` for Phase 6 and deferred items.
+See `.claude/docs/roadmap.md` for next steps. Always keep these in mind to not introduce any roadblocks along the way.

--- a/.claude/skills/github-workflow/SKILL.md
+++ b/.claude/skills/github-workflow/SKILL.md
@@ -15,6 +15,7 @@ description: Git and GitHub workflow rules for the coach project. Use this skill
 ## Pull requests
 - Always rebase merge: `gh pr merge --rebase` (not squash or merge commits)
 - **Always `git push` before `gh pr merge --rebase`** — the command merges the remote branch; local-only commits not yet pushed are silently left behind
+- Always check that the CI has passed after pushing to the remote branch - do not report success before you can report also success on CI
 
 ## Issues
 - `gh issue close` accepts one issue at a time — loop for multiple:

--- a/coach/web/strava_webhook.py
+++ b/coach/web/strava_webhook.py
@@ -1,3 +1,6 @@
+import hashlib
+import hmac
+import json
 import logging
 import os
 from typing import Any
@@ -19,6 +22,12 @@ from coach.persistence.repositories.users import SupabaseUsersRepository
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+def _verify_strava_signature(body: bytes, signature_header: str) -> bool:
+    client_secret = os.environ.get('STRAVA_CLIENT_SECRET', '')
+    expected = 'sha256=' + hmac.new(client_secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
 
 
 def _get_verify_token() -> str:
@@ -44,7 +53,11 @@ async def strava_webhook_event(
     request: Request,
     secret_client: Client = Depends(create_secret_client),  # noqa: B008
 ) -> dict[str, str]:
-    payload: dict[str, Any] = await request.json()
+    body = await request.body()
+    if not _verify_strava_signature(body, request.headers.get('X-Hub-Signature', '')):
+        raise HTTPException(status_code=403, detail='Invalid webhook signature')
+
+    payload: dict[str, Any] = json.loads(body)
 
     object_type = payload.get('object_type')
     aspect_type = payload.get('aspect_type')

--- a/coach/web/tests/test_strava_webhook.py
+++ b/coach/web/tests/test_strava_webhook.py
@@ -1,3 +1,6 @@
+import hashlib
+import hmac
+import json
 import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -8,6 +11,7 @@ from coach.persistence.database import create_secret_client
 from coach.web.app import create_app
 
 _VERIFY_TOKEN = 'test-verify-token'
+_CLIENT_SECRET = 'test-client-secret'
 
 
 def _make_test_client() -> tuple[TestClient, MagicMock]:
@@ -15,6 +19,12 @@ def _make_test_client() -> tuple[TestClient, MagicMock]:
     app = create_app()
     app.dependency_overrides[create_secret_client] = lambda: secret_client
     return TestClient(app, raise_server_exceptions=False), secret_client
+
+
+def _signed_post(http: TestClient, payload: dict) -> object:
+    body = json.dumps(payload).encode()
+    sig = 'sha256=' + hmac.new(_CLIENT_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return http.post('/webhook/strava', content=body, headers={'Content-Type': 'application/json', 'X-Hub-Signature': sig})
 
 
 class TestStravaWebhookChallenge:
@@ -45,87 +55,57 @@ class TestStravaWebhookChallenge:
 class TestStravaWebhookEvent:
     def setup_method(self) -> None:
         self._http, self._secret_client = _make_test_client()
+        self._env_patcher = patch.dict(os.environ, {'STRAVA_CLIENT_SECRET': _CLIENT_SECRET})
+        self._env_patcher.start()
+
+    def teardown_method(self) -> None:
+        self._env_patcher.stop()
+
+    def test_missing_signature_returns_403(self) -> None:
+        response = self._http.post('/webhook/strava', json={'object_type': 'athlete', 'aspect_type': 'deauthorization', 'owner_id': 42})
+
+        assert response.status_code == 403
+
+    def test_invalid_signature_returns_403(self) -> None:
+        response = self._http.post('/webhook/strava', json={'object_type': 'athlete'}, headers={'X-Hub-Signature': 'sha256=deadbeef'})
+
+        assert response.status_code == 403
 
     def test_deauthorization_event_calls_deauthorize(self) -> None:
         with patch('coach.web.strava_webhook.deauthorize_athlete') as mock_deauth:
-            response = self._http.post(
-                '/webhook/strava',
-                json={
-                    'object_type': 'athlete',
-                    'aspect_type': 'deauthorization',
-                    'owner_id': 42,
-                    'object_id': 42,
-                },
-            )
+            response = _signed_post(self._http, {'object_type': 'athlete', 'aspect_type': 'deauthorization', 'owner_id': 42, 'object_id': 42})
 
         assert response.status_code == 200
         mock_deauth.assert_called_once_with(42, mock_deauth.call_args[0][1])
 
     def test_activity_create_event_dispatches_handler(self) -> None:
         with patch('coach.web.strava_webhook._handle_activity_event') as mock_handler:
-            response = self._http.post(
-                '/webhook/strava',
-                json={
-                    'object_type': 'activity',
-                    'aspect_type': 'create',
-                    'owner_id': 42,
-                    'object_id': 999,
-                },
-            )
+            response = _signed_post(self._http, {'object_type': 'activity', 'aspect_type': 'create', 'owner_id': 42, 'object_id': 999})
 
         assert response.status_code == 200
         mock_handler.assert_called_once_with('create', 42, 999, mock_handler.call_args[0][3])
 
     def test_activity_update_event_dispatches_handler(self) -> None:
         with patch('coach.web.strava_webhook._handle_activity_event') as mock_handler:
-            response = self._http.post(
-                '/webhook/strava',
-                json={
-                    'object_type': 'activity',
-                    'aspect_type': 'update',
-                    'owner_id': 42,
-                    'object_id': 999,
-                },
-            )
+            response = _signed_post(self._http, {'object_type': 'activity', 'aspect_type': 'update', 'owner_id': 42, 'object_id': 999})
 
         assert response.status_code == 200
         mock_handler.assert_called_once()
 
     def test_activity_delete_event_dispatches_handler(self) -> None:
         with patch('coach.web.strava_webhook._handle_activity_event') as mock_handler:
-            response = self._http.post(
-                '/webhook/strava',
-                json={
-                    'object_type': 'activity',
-                    'aspect_type': 'delete',
-                    'owner_id': 42,
-                    'object_id': 999,
-                },
-            )
+            response = _signed_post(self._http, {'object_type': 'activity', 'aspect_type': 'delete', 'owner_id': 42, 'object_id': 999})
 
         assert response.status_code == 200
         mock_handler.assert_called_once_with('delete', 42, 999, mock_handler.call_args[0][3])
 
     def test_unrecognised_event_returns_200(self) -> None:
-        response = self._http.post(
-            '/webhook/strava',
-            json={
-                'object_type': 'something_new',
-                'aspect_type': 'unknown',
-            },
-        )
+        response = _signed_post(self._http, {'object_type': 'something_new', 'aspect_type': 'unknown'})
 
         assert response.status_code == 200
 
     def test_missing_owner_id_returns_200(self) -> None:
-        response = self._http.post(
-            '/webhook/strava',
-            json={
-                'object_type': 'activity',
-                'aspect_type': 'create',
-                'object_id': 999,
-            },
-        )
+        response = _signed_post(self._http, {'object_type': 'activity', 'aspect_type': 'create', 'object_id': 999})
 
         assert response.status_code == 200
 

--- a/coach/web/tests/test_strava_webhook.py
+++ b/coach/web/tests/test_strava_webhook.py
@@ -5,6 +5,7 @@ import os
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import httpx
 from fastapi.testclient import TestClient
 
 from coach.persistence.database import create_secret_client
@@ -21,7 +22,7 @@ def _make_test_client() -> tuple[TestClient, MagicMock]:
     return TestClient(app, raise_server_exceptions=False), secret_client
 
 
-def _signed_post(http: TestClient, payload: dict) -> object:
+def _signed_post(http: TestClient, payload: dict) -> httpx.Response:
     body = json.dumps(payload).encode()
     sig = 'sha256=' + hmac.new(_CLIENT_SECRET.encode(), body, hashlib.sha256).hexdigest()
     return http.post('/webhook/strava', content=body, headers={'Content-Type': 'application/json', 'X-Hub-Signature': sig})


### PR DESCRIPTION
## Summary

- Unsigned POST requests to `/webhook/strava` could forge arbitrary deauthorization or activity events for any Strava athlete ID, triggering data deletion with no authentication
- Now reads raw body, computes `HMAC-SHA256(body, STRAVA_CLIENT_SECRET)`, and rejects requests where `X-Hub-Signature` is missing or mismatched (403)
- Updated all `TestStravaWebhookEvent` tests to send correctly signed payloads; added `test_missing_signature_returns_403` and `test_invalid_signature_returns_403`

## Test plan

- [ ] All 269 tests pass
- [ ] CI passes
- [ ] `STRAVA_CLIENT_SECRET` is already set in Railway (used by the OAuth flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)