### PR TITLE
feat: pace zones and workout intensity classification

### DIFF
--- a/coach/builders/pace_zones.py
+++ b/coach/builders/pace_zones.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from coach.domain.personal_bests import RunningPersonalBestsSummary
+from coach.domain.training_analytics import PaceZones
+
+
+def _parse_pace_secs(pace_str: str) -> int:
+    """Parse 'M:SS/km' to total seconds per km."""
+    time_part = pace_str.split('/')[0]
+    minutes_str, seconds_str = time_part.split(':')
+    return int(minutes_str) * 60 + int(seconds_str)
+
+
+def _format_pace_secs(secs: int) -> str:
+    """Format total seconds per km to 'M:SS/km'."""
+    minutes = secs // 60
+    seconds = secs % 60
+    return f'{minutes}:{seconds:02d}/km'
+
+
+def build_pace_zones(pb_summary: RunningPersonalBestsSummary) -> Optional[PaceZones]:
+    candidates = [
+        ('5K', pb_summary.PB_5K, 0),
+        ('10K', pb_summary.PB_10K, -13),
+        ('Half-Marathon', pb_summary.PB_HALF_MARATHON, -30),
+        ('Marathon', pb_summary.PB_MARATHON, -50),
+        ('1K', pb_summary.PB_1K, 15),
+    ]
+
+    for reference_distance, pb, adjustment in candidates:
+        if pb is None:
+            continue
+
+        pace_secs = _parse_pace_secs(pb.pace_str)
+        ref_secs = pace_secs + adjustment
+
+        easy_secs = ref_secs + 65
+        marathon_secs = ref_secs + 40
+        threshold_secs = ref_secs + 15
+        interval_secs = ref_secs
+
+        return PaceZones(
+            reference_distance=reference_distance,
+            easy_pace=_format_pace_secs(easy_secs),
+            marathon_pace=_format_pace_secs(marathon_secs),
+            threshold_pace=_format_pace_secs(threshold_secs),
+            interval_pace=_format_pace_secs(interval_secs),
+        )
+
+    return None

--- a/coach/builders/tests/test_pace_zones.py
+++ b/coach/builders/tests/test_pace_zones.py
@@ -1,0 +1,127 @@
+from datetime import date
+
+from coach.builders.pace_zones import _format_pace_secs
+from coach.builders.pace_zones import _parse_pace_secs
+from coach.builders.pace_zones import build_pace_zones
+from coach.domain.personal_bests import RunningPersonalBest
+from coach.domain.personal_bests import RunningPersonalBestsSummary
+
+_NO_PBS = RunningPersonalBestsSummary(
+    PB_1K=None,
+    PB_5K=None,
+    PB_10K=None,
+    PB_15K=None,
+    PB_HALF_MARATHON=None,
+    PB_MARATHON=None,
+)
+
+_SAMPLE_DATE = date(2025, 1, 1)
+
+
+def _make_pb(pace_str: str) -> RunningPersonalBest:
+    return RunningPersonalBest(achieved_on=_SAMPLE_DATE, pace_str=pace_str)
+
+
+def _pb_summary(
+    *,
+    pb_1k: str | None = None,
+    pb_5k: str | None = None,
+    pb_10k: str | None = None,
+    pb_half: str | None = None,
+    pb_marathon: str | None = None,
+) -> RunningPersonalBestsSummary:
+    return RunningPersonalBestsSummary(
+        PB_1K=_make_pb(pb_1k) if pb_1k else None,
+        PB_5K=_make_pb(pb_5k) if pb_5k else None,
+        PB_10K=_make_pb(pb_10k) if pb_10k else None,
+        PB_15K=None,
+        PB_HALF_MARATHON=_make_pb(pb_half) if pb_half else None,
+        PB_MARATHON=_make_pb(pb_marathon) if pb_marathon else None,
+    )
+
+
+class TestParsePaceSecs:
+    def test_parses_basic_pace(self) -> None:
+        assert _parse_pace_secs('4:30/km') == 270
+
+    def test_parses_pace_with_leading_zero_seconds(self) -> None:
+        assert _parse_pace_secs('5:05/km') == 305
+
+    def test_parses_single_digit_minutes(self) -> None:
+        assert _parse_pace_secs('3:00/km') == 180
+
+
+class TestFormatPaceSecs:
+    def test_formats_to_string(self) -> None:
+        assert _format_pace_secs(270) == '4:30/km'
+
+    def test_pads_seconds(self) -> None:
+        assert _format_pace_secs(305) == '5:05/km'
+
+    def test_round_trip(self) -> None:
+        assert _format_pace_secs(_parse_pace_secs('6:15/km')) == '6:15/km'
+
+
+class TestBuildPaceZones:
+    def test_no_pbs_returns_none(self) -> None:
+        result = build_pace_zones(_NO_PBS)
+        assert result is None
+
+    def test_5k_pb_uses_no_adjustment(self) -> None:
+        # 5K pace 4:00/km = 240 sec/km, no adjustment → ref=240
+        # Easy = 240+65=305 = 5:05/km
+        # Marathon = 240+40=280 = 4:40/km
+        # Threshold = 240+15=255 = 4:15/km
+        # Interval = 240+0=240 = 4:00/km
+        result = build_pace_zones(_pb_summary(pb_5k='4:00/km'))
+        assert result is not None
+        assert result.reference_distance == '5K'
+        assert result.easy_pace == '5:05/km'
+        assert result.marathon_pace == '4:40/km'
+        assert result.threshold_pace == '4:15/km'
+        assert result.interval_pace == '4:00/km'
+
+    def test_10k_pb_applies_minus_13_adjustment(self) -> None:
+        # 10K pace 4:00/km = 240 sec/km, adjustment=-13 → ref=227
+        # Easy = 227+65=292 = 4:52/km
+        # Interval = 227+0=227 = 3:47/km
+        result = build_pace_zones(_pb_summary(pb_10k='4:00/km'))
+        assert result is not None
+        assert result.reference_distance == '10K'
+        assert result.interval_pace == '3:47/km'
+        assert result.easy_pace == '4:52/km'
+
+    def test_5k_takes_priority_over_10k(self) -> None:
+        result = build_pace_zones(_pb_summary(pb_5k='4:00/km', pb_10k='3:50/km'))
+        assert result is not None
+        assert result.reference_distance == '5K'
+
+    def test_half_marathon_pb_applies_minus_30_adjustment(self) -> None:
+        # Half pace 4:30/km = 270 sec/km, adjustment=-30 → ref=240
+        result = build_pace_zones(_pb_summary(pb_half='4:30/km'))
+        assert result is not None
+        assert result.reference_distance == 'Half-Marathon'
+        assert result.interval_pace == '4:00/km'
+
+    def test_1k_pb_applies_plus_15_adjustment(self) -> None:
+        # 1K pace 3:30/km = 210 sec/km, adjustment=+15 → ref=225
+        result = build_pace_zones(_pb_summary(pb_1k='3:30/km'))
+        assert result is not None
+        assert result.reference_distance == '1K'
+        assert result.interval_pace == '3:45/km'
+
+    def test_zone_ordering_easy_slowest(self) -> None:
+        result = build_pace_zones(_pb_summary(pb_5k='4:00/km'))
+        assert result is not None
+        easy_secs = _parse_pace_secs(result.easy_pace)
+        marathon_secs = _parse_pace_secs(result.marathon_pace)
+        threshold_secs = _parse_pace_secs(result.threshold_pace)
+        interval_secs = _parse_pace_secs(result.interval_pace)
+        assert easy_secs > marathon_secs > threshold_secs >= interval_secs
+
+    def test_all_outputs_are_pace_strings(self) -> None:
+        result = build_pace_zones(_pb_summary(pb_5k='4:00/km'))
+        assert result is not None
+        for pace in (result.easy_pace, result.marathon_pace, result.threshold_pace, result.interval_pace):
+            assert '/km' in pace
+            assert ':' in pace

--- a/coach/builders/tests/test_workout_classifier.py
+++ b/coach/builders/tests/test_workout_classifier.py
@@ -1,0 +1,130 @@
+from datetime import UTC
+from datetime import date
+from datetime import datetime
+from typing import Optional
+
+from coach.builders.pace_zones import build_pace_zones
+from coach.builders.workout_classifier import classify_run_workout
+from coach.domain.activity import SportType
+from coach.domain.personal_bests import RunningPersonalBest
+from coach.domain.personal_bests import RunningPersonalBestsSummary
+from coach.domain.training_analytics import PaceZones
+from coach.domain.training_summaries import ActivitySummary
+
+_START = datetime(2025, 1, 1, tzinfo=UTC)
+
+
+def _make_pace_zones() -> Optional[PaceZones]:
+    pb = RunningPersonalBest(achieved_on=date(2025, 1, 1), pace_str='4:00/km')
+    return build_pace_zones(
+        RunningPersonalBestsSummary(
+            PB_1K=None,
+            PB_5K=pb,
+            PB_10K=None,
+            PB_15K=None,
+            PB_HALF_MARATHON=None,
+            PB_MARATHON=None,
+        ),
+    )
+
+
+def _run(
+    *,
+    elapsed: int = 3000,
+    moving: int | None = 3000,
+    avg_hr: float | None = None,
+    max_hr: float | None = None,
+    distance: float | None = 5000.0,
+) -> ActivitySummary:
+    return ActivitySummary(
+        start_time_utc=_START,
+        sport_type=SportType.RUN,
+        title='Test Run',
+        elapsed_time_seconds=elapsed,
+        moving_time_seconds=moving,
+        distance_meters=distance,
+        average_heart_rate=avg_hr,
+        max_heart_rate=max_hr,
+    )
+
+
+def _non_run() -> ActivitySummary:
+    return ActivitySummary(
+        start_time_utc=_START,
+        sport_type=SportType.RIDE,
+        title='Ride',
+        elapsed_time_seconds=3600,
+    )
+
+
+class TestClassifyRunWorkout:
+    def test_non_run_returns_none(self) -> None:
+        assert classify_run_workout(_non_run(), max_hr_estimate=180.0, pace_zones=None) is None
+
+    def test_run_no_hr_no_pace_zones_returns_none(self) -> None:
+        assert classify_run_workout(_run(), max_hr_estimate=None, pace_zones=None) is None
+
+    def test_interval_hr_based(self) -> None:
+        # ratio = 2700/3600 = 0.75 < 0.87; max_hr=188 >= 188*0.92=173
+        activity = _run(elapsed=3600, moving=2700, max_hr=188.0)
+        result = classify_run_workout(activity, max_hr_estimate=188.0, pace_zones=None)
+        assert result == 'Interval'
+
+    def test_interval_hr_based_requires_sufficient_max_hr(self) -> None:
+        # ratio low but max_hr too low → no interval via HR
+        activity = _run(elapsed=3600, moving=2700, max_hr=150.0, avg_hr=140.0)
+        result = classify_run_workout(activity, max_hr_estimate=188.0, pace_zones=None)
+        # avg_hr 140 <= 188*0.77=144.8, elapsed=3600 < 3900 → Easy
+        assert result == 'Easy'
+
+    def test_interval_pace_based_fallback(self) -> None:
+        # ratio 0.75 < 0.87; no HR data; fast pace ≤ threshold+30
+        # 5K PB 4:00/km → threshold=4:15/km=255 sec/km; threshold+30=285 sec/km
+        # moving=2700s, distance=5000m → pace = 2700/(5000/1000) = 540 sec/km → too slow
+        # Use a fast pace: distance=7000m, moving=1700s → pace = 1700/7 = 243 sec/km ≤ 285 → Interval
+        pace_zones = _make_pace_zones()
+        activity = _run(elapsed=2500, moving=1700, distance=7000.0)
+        result = classify_run_workout(activity, max_hr_estimate=None, pace_zones=pace_zones)
+        assert result == 'Interval'
+
+    def test_tempo_hr_based(self) -> None:
+        # avg_hr=165, max_hr_estimate=190 → 165 >= 190*0.85=161.5
+        activity = _run(avg_hr=165.0)
+        result = classify_run_workout(activity, max_hr_estimate=190.0, pace_zones=None)
+        assert result == 'Tempo'
+
+    def test_tempo_pace_based_fallback(self) -> None:
+        # No HR; threshold=4:15/km=255 sec/km; threshold+20=275 sec/km
+        # distance=5000m, moving=1300s → pace = 1300/5 = 260 sec/km ≤ 275 → Tempo
+        pace_zones = _make_pace_zones()
+        activity = _run(elapsed=1400, moving=1300, distance=5000.0)
+        result = classify_run_workout(activity, max_hr_estimate=None, pace_zones=pace_zones)
+        assert result == 'Tempo'
+
+    def test_long_run(self) -> None:
+        # avg_hr=140 <= 188*0.77=144.8; elapsed=4200 >= 3900
+        activity = _run(elapsed=4200, moving=4200, avg_hr=140.0)
+        result = classify_run_workout(activity, max_hr_estimate=188.0, pace_zones=None)
+        assert result == 'Long Run'
+
+    def test_easy_run(self) -> None:
+        # avg_hr=130 <= 188*0.77=144.8; elapsed=2400 < 3900
+        activity = _run(elapsed=2400, moving=2400, avg_hr=130.0)
+        result = classify_run_workout(activity, max_hr_estimate=188.0, pace_zones=None)
+        assert result == 'Easy'
+
+    def test_slow_pace_with_zones_returns_none_no_hr(self) -> None:
+        # Slow pace: distance=5000m, moving=3000s → 600 sec/km; far above threshold zone
+        pace_zones = _make_pace_zones()
+        activity = _run(elapsed=3000, moving=3000, distance=5000.0)
+        result = classify_run_workout(activity, max_hr_estimate=None, pace_zones=pace_zones)
+        assert result is None
+
+    def test_strength_activity_returns_none(self) -> None:
+        activity = ActivitySummary(
+            start_time_utc=_START,
+            sport_type=SportType.STRENGTH,
+            title='Upper Body',
+            elapsed_time_seconds=3600,
+        )
+        assert classify_run_workout(activity, max_hr_estimate=180.0, pace_zones=None) is None

--- a/coach/builders/workout_classifier.py
+++ b/coach/builders/workout_classifier.py
@@ -1,0 +1,71 @@
+from typing import Optional
+
+from coach.builders.pace_zones import _parse_pace_secs
+from coach.domain.activity import SportType
+from coach.domain.training_analytics import PaceZones
+from coach.domain.training_summaries import ActivitySummary
+
+_INTERVAL_RATIO_THRESHOLD = 0.87
+_INTERVAL_MAX_HR_FRACTION = 0.92
+_TEMPO_AVG_HR_FRACTION = 0.85
+_EASY_AVG_HR_FRACTION = 0.77
+_LONG_RUN_ELAPSED_SECONDS = 3900  # 65 minutes
+
+
+def _activity_pace_secs(activity: ActivitySummary) -> Optional[int]:
+    if activity.distance_meters is None or not activity.distance_meters:
+        return None
+    if activity.moving_time_seconds is None or not activity.moving_time_seconds:
+        return None
+    return int(activity.moving_time_seconds / (activity.distance_meters / 1000))
+
+
+def classify_run_workout(
+    activity: ActivitySummary,
+    max_hr_estimate: Optional[float],
+    pace_zones: Optional[PaceZones],
+) -> Optional[str]:
+    if activity.sport_type != SportType.RUN:
+        return None
+
+    moving = activity.moving_time_seconds
+    elapsed = activity.elapsed_time_seconds
+    avg_hr = activity.average_heart_rate
+    max_hr = activity.max_heart_rate
+
+    has_rest = moving is not None and elapsed > 0 and moving / elapsed < _INTERVAL_RATIO_THRESHOLD
+    activity_pace = _activity_pace_secs(activity)
+    threshold_secs = _parse_pace_secs(pace_zones.threshold_pace) if pace_zones else None
+
+    # Interval — HR-based
+    if (
+        moving is not None
+        and elapsed > 0
+        and moving / elapsed < _INTERVAL_RATIO_THRESHOLD
+        and max_hr is not None
+        and max_hr_estimate is not None
+        and max_hr >= max_hr_estimate * _INTERVAL_MAX_HR_FRACTION
+    ):
+        return 'Interval'
+
+    # Interval — pace-based fallback
+    if has_rest and pace_zones is not None and activity_pace is not None and threshold_secs is not None and activity_pace <= threshold_secs + 30:
+        return 'Interval'
+
+    # Tempo — HR-based
+    if avg_hr is not None and max_hr_estimate is not None and avg_hr >= max_hr_estimate * _TEMPO_AVG_HR_FRACTION:
+        return 'Tempo'
+
+    # Tempo — pace-based fallback
+    if pace_zones is not None and activity_pace is not None and threshold_secs is not None and activity_pace <= threshold_secs + 20:
+        return 'Tempo'
+
+    # Long Run
+    if avg_hr is not None and max_hr_estimate is not None and avg_hr <= max_hr_estimate * _EASY_AVG_HR_FRACTION and elapsed >= _LONG_RUN_ELAPSED_SECONDS:
+        return 'Long Run'
+
+    # Easy
+    if avg_hr is not None and max_hr_estimate is not None and avg_hr <= max_hr_estimate * _EASY_AVG_HR_FRACTION:
+        return 'Easy'
+
+    return None

--- a/coach/domain/training_analytics.py
+++ b/coach/domain/training_analytics.py
@@ -35,3 +35,12 @@ class ActiveTrainingPhase:
     phase: TrainingMacroPhase
     weeks_to_goal: Optional[int]
     goal_name: Optional[str]
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class PaceZones:
+    reference_distance: str  # e.g. '5K', '10K'
+    easy_pace: str  # 'M:SS/km'
+    marathon_pace: str
+    threshold_pace: str
+    interval_pace: str

--- a/coach/reasoning/coach/context.py
+++ b/coach/reasoning/coach/context.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from coach.builders.pace_zones import build_pace_zones
 from coach.builders.training_phase import detect_training_phase
 from coach.builders.training_trends import build_training_trends
 from coach.domain.personal_bests import RunningPersonalBestsSummary
@@ -7,6 +8,7 @@ from coach.domain.profile import UserProfile
 from coach.domain.training_summaries import RecentTrainingHistory
 from coach.reasoning.coach.sections import ContextSection
 from coach.reasoning.coach.sections import GoalStateSection
+from coach.reasoning.coach.sections import PaceZonesSection
 from coach.reasoning.coach.sections import PersonalBestsSection
 from coach.reasoning.coach.sections import ProfileSection
 from coach.reasoning.coach.sections import TrainingHistorySection
@@ -26,6 +28,7 @@ def build_coach_context(
         profile.goals if profile and profile.goals else (),
         recent_training_history.generated_at,
     )
+    pace_zones = build_pace_zones(pb_summary)
 
     sections: list[ContextSection] = []
     sections.append(TrainingPhaseSection(training_phase))
@@ -33,7 +36,8 @@ def build_coach_context(
         sections.append(ProfileSection(profile))
         sections.append(GoalStateSection(profile, pb_summary))
     sections.append(TrainingTrendsSection(training_trends))
-    sections.append(TrainingHistorySection(recent_training_history))
+    sections.append(PaceZonesSection(pace_zones))
+    sections.append(TrainingHistorySection(recent_training_history, pace_zones=pace_zones))
     sections.append(PersonalBestsSection(pb_summary))
 
     rendered_pairs = [(s.header, s.render()) for s in sections]

--- a/coach/reasoning/coach/sections/__init__.py
+++ b/coach/reasoning/coach/sections/__init__.py
@@ -1,5 +1,6 @@
 from coach.reasoning.coach.sections.base import ContextSection
 from coach.reasoning.coach.sections.goal_state import GoalStateSection
+from coach.reasoning.coach.sections.pace_zones import PaceZonesSection
 from coach.reasoning.coach.sections.personal_bests import PersonalBestsSection
 from coach.reasoning.coach.sections.profile import ProfileSection
 from coach.reasoning.coach.sections.training_history import TrainingHistorySection
@@ -9,6 +10,7 @@ from coach.reasoning.coach.sections.training_trends import TrainingTrendsSection
 __all__ = [
     'ContextSection',
     'GoalStateSection',
+    'PaceZonesSection',
     'PersonalBestsSection',
     'ProfileSection',
     'TrainingHistorySection',

--- a/coach/reasoning/coach/sections/pace_zones.py
+++ b/coach/reasoning/coach/sections/pace_zones.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from coach.domain.training_analytics import PaceZones
+from coach.reasoning.coach.sections.base import ContextSection
+
+
+class PaceZonesSection(ContextSection):
+    def __init__(self, pace_zones: Optional[PaceZones]) -> None:
+        self._pace_zones = pace_zones
+
+    @property
+    def header(self) -> str:
+        return 'Training pace zones:'
+
+    def render(self) -> Optional[str]:
+        if self._pace_zones is None:
+            return None
+
+        lines: list[str] = []
+        lines.append(f'Derived from {self._pace_zones.reference_distance} PB:')
+        lines.append(f'- Easy: {self._pace_zones.easy_pace}')
+        lines.append(f'- Marathon: {self._pace_zones.marathon_pace}')
+        lines.append(f'- Threshold: {self._pace_zones.threshold_pace}')
+        lines.append(f'- Interval / VO2max: {self._pace_zones.interval_pace}')
+        return '\n'.join(lines)

--- a/coach/reasoning/coach/sections/tests/test_training_history.py
+++ b/coach/reasoning/coach/sections/tests/test_training_history.py
@@ -256,3 +256,140 @@ Ride: Ride 1
         assert 'Active time' not in result
         assert 'Elapsed time' not in result
         assert 'Active pace' not in result
+
+    def test_classification_label_appears_for_easy_run(self) -> None:
+        # avg_hr=130, max_hr=160 → 130 <= 160*0.77=123.2? No, 130 > 123.2 → not easy by HR
+        # Use avg_hr=120, max_hr=160 → 120 <= 123.2 → Easy, elapsed=2400 < 3900
+        self._weekly_activities['Monday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.RUN,
+                title='Morning run',
+                elapsed_time_seconds=2_400,
+                moving_time_seconds=2_400,
+                distance_meters=5_000,
+                average_heart_rate=120.0,
+                max_heart_rate=160.0,
+            ),
+        ]
+        volume = {SportType.RUN: ActivityVolume(num_activities=1, duration_seconds=2400, distance_meters=5000.0)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert 'Run (Easy): Morning run' in result
+
+    def test_classification_label_appears_for_interval_run(self) -> None:
+        # ratio=2700/3600=0.75 < 0.87 AND max_hr=185 >= 185*0.92=170.2
+        self._weekly_activities['Wednesday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.RUN,
+                title='Track session',
+                elapsed_time_seconds=3_600,
+                moving_time_seconds=2_700,
+                distance_meters=7_000,
+                average_heart_rate=170.0,
+                max_heart_rate=185.0,
+            ),
+        ]
+        volume = {SportType.RUN: ActivityVolume(num_activities=1, duration_seconds=2700, distance_meters=7000.0)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert 'Run (Interval): Track session' in result
+
+    def test_non_run_activity_keeps_original_format(self) -> None:
+        self._weekly_activities['Monday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.STRENGTH,
+                title='Squats',
+                elapsed_time_seconds=3_600,
+                average_heart_rate=120.0,
+                max_heart_rate=160.0,
+            ),
+        ]
+        volume = {SportType.STRENGTH: ActivityVolume(num_activities=1, duration_seconds=3600, distance_meters=None)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert 'WeightTraining: Squats' in result
+        assert '(' not in result.split('WeightTraining: Squats')[0].split('---')[-1]
+
+    def test_intensity_distribution_block_appears_for_classified_runs(self) -> None:
+        # Two runs: one easy, one interval
+        self._weekly_activities['Monday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.RUN,
+                title='Easy run',
+                elapsed_time_seconds=2_400,
+                moving_time_seconds=2_400,
+                average_heart_rate=120.0,
+                max_heart_rate=185.0,
+            ),
+        ]
+        self._weekly_activities['Wednesday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.RUN,
+                title='Intervals',
+                elapsed_time_seconds=3_600,
+                moving_time_seconds=2_700,
+                average_heart_rate=170.0,
+                max_heart_rate=185.0,
+            ),
+        ]
+        volume = {SportType.RUN: ActivityVolume(num_activities=2, duration_seconds=5100, distance_meters=12000.0)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert '----- Run intensity -----' in result
+        assert 'Easy: 1' in result
+        assert 'Interval: 1' in result
+
+    def test_no_intensity_distribution_when_no_runs_classified(self) -> None:
+        # Strength only — no runs to classify
+        self._weekly_activities['Monday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.STRENGTH,
+                title='Upper body',
+                elapsed_time_seconds=3_600,
+            ),
+        ]
+        volume = {SportType.STRENGTH: ActivityVolume(num_activities=1, duration_seconds=3600, distance_meters=None)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert 'Run intensity' not in result
+
+    def test_no_intensity_distribution_for_unclassifiable_runs(self) -> None:
+        # Run with no HR and no pace zones — unclassifiable
+        self._weekly_activities['Monday'] = [
+            ActivitySummary(
+                start_time_utc=datetime(2024, 1, 8, 12, tzinfo=UTC),
+                sport_type=SportType.RUN,
+                title='Run',
+                elapsed_time_seconds=3_000,
+                moving_time_seconds=3_000,
+                distance_meters=5_000,
+            ),
+        ]
+        volume = {SportType.RUN: ActivityVolume(num_activities=1, duration_seconds=3000, distance_meters=5000.0)}
+        history = _make_current_week_history(self._weekly_activities, volume)
+
+        section = TrainingHistorySection(history)
+        result = section.render()
+        assert result is not None
+        assert 'Run intensity' not in result

--- a/coach/reasoning/coach/sections/training_history.py
+++ b/coach/reasoning/coach/sections/training_history.py
@@ -1,8 +1,10 @@
 from typing import Optional
 from typing import cast
 
+from coach.builders.workout_classifier import classify_run_workout
 from coach.domain.activity import DISTANCE_SPORT_TYPES
 from coach.domain.activity import SportType
+from coach.domain.training_analytics import PaceZones
 from coach.domain.training_summaries import ActivitySummary
 from coach.domain.training_summaries import ActivityVolume
 from coach.domain.training_summaries import RecentTrainingHistory
@@ -47,9 +49,26 @@ def _render_pace(activity_summary: ActivitySummary, active_seconds: int, has_res
     return f'- Pace: {active_pace}'
 
 
+def _collect_all_activities(history: RecentTrainingHistory) -> list[ActivitySummary]:
+    all_activities: list[ActivitySummary] = []
+    for weekly in history.history_weekly_summaries:
+        for day_activities in weekly.activity_summaries.values():
+            all_activities.extend(cast(list[ActivitySummary], day_activities))
+    for day_activities in history.current_week_summary.activity_summaries.values():
+        all_activities.extend(cast(list[ActivitySummary], day_activities))
+    return all_activities
+
+
 class TrainingHistorySection(ContextSection):
-    def __init__(self, recent_training_history: RecentTrainingHistory) -> None:
+    def __init__(self, recent_training_history: RecentTrainingHistory, *, pace_zones: Optional[PaceZones] = None) -> None:
         self._history = recent_training_history
+        self._pace_zones = pace_zones
+
+        max_hr: Optional[float] = None
+        for activity in _collect_all_activities(recent_training_history):
+            if activity.max_heart_rate is not None and (max_hr is None or activity.max_heart_rate > max_hr):
+                max_hr = activity.max_heart_rate
+        self._max_hr_estimate = max_hr
 
     @property
     def header(self) -> str:
@@ -78,6 +97,11 @@ class TrainingHistorySection(ContextSection):
         lines.append(f'Weekly summary for {weekly_summary.week_start} to {weekly_summary.week_end}:')
         lines.append('----- Per-day breakdown -----')
         lines.append(self._render_weekly_activities(weekly_summary.activity_summaries))
+
+        intensity_block = self._render_intensity_distribution(weekly_summary.activity_summaries)
+        if intensity_block:
+            lines.append(intensity_block)
+
         lines.append('----- Volume aggregation by sport -----')
         for sport, volume in weekly_summary.volume_by_sport.items():
             lines.append(f'--- {sport.value} ---')
@@ -96,14 +120,32 @@ class TrainingHistorySection(ContextSection):
                     lines.append('')
         return '\n'.join(lines)
 
-    @staticmethod
-    def _render_activity_summary(activity_summary: ActivitySummary) -> str:
+    def _render_intensity_distribution(self, weekly_activities: WeeklyActivities) -> Optional[str]:
+        counts: dict[str, int] = {}
+        for day_activities in weekly_activities.values():
+            for activity in cast(list[ActivitySummary], day_activities):
+                label = classify_run_workout(activity, self._max_hr_estimate, self._pace_zones)
+                if label is not None:
+                    counts[label] = counts.get(label, 0) + 1
+        if not counts:
+            return None
+        label_order = ['Easy', 'Long Run', 'Tempo', 'Interval']
+        parts = [f'{label}: {counts[label]}' for label in label_order if label in counts]
+        return '----- Run intensity -----\n' + ' | '.join(parts)
+
+    def _render_activity_summary(self, activity_summary: ActivitySummary) -> str:
         is_distance = activity_summary.sport_type in DISTANCE_SPORT_TYPES
         active_seconds = activity_summary.moving_time_seconds or activity_summary.elapsed_time_seconds
         has_rest = activity_summary.moving_time_seconds is not None and activity_summary.moving_time_seconds < activity_summary.elapsed_time_seconds
 
+        label = classify_run_workout(activity_summary, self._max_hr_estimate, self._pace_zones)
+        if label is not None:
+            sport_line = f'{activity_summary.sport_type.value} ({label}): {activity_summary.title}'
+        else:
+            sport_line = f'{activity_summary.sport_type.value}: {activity_summary.title}'
+
         lines: list[str] = []
-        lines.append(f'{activity_summary.sport_type.value}: {activity_summary.title}')
+        lines.append(sport_line)
         lines.append(_render_time(activity_summary, active_seconds, has_rest))
         if is_distance:
             distance_km = parse_distance_km(meters=activity_summary.distance_meters, decimals=1)

--- a/coach/reasoning/coach/tests/test_context.py
+++ b/coach/reasoning/coach/tests/test_context.py
@@ -233,7 +233,7 @@ Summary of recent training history:
 Weekly summary for 2025-03-03 to 2025-03-09:
 ----- Per-day breakdown -----
 --- Monday ---
-Run: Easy Run
+Run (Easy): Easy Run
 - Moving time: 00:50:00 (no rest)
 - Distance: 8.0 km
 - Pace: 6:15/km
@@ -243,7 +243,7 @@ Run: Easy Run
 - Notes: easy aerobic
 
 --- Wednesday ---
-Run: Intervals
+Run (Interval): Intervals
 - Active time: 00:45:00
 - Elapsed time: 01:00:00 (rest: 00:15:00)
 - Distance: 7.0 km
@@ -259,6 +259,8 @@ WeightTraining: Upper Body
 - Moving time: 00:45:00 (no rest)
 - Notes: upper body strength
 
+----- Run intensity -----
+Easy: 1 | Interval: 1
 ----- Volume aggregation by sport -----
 --- Run ---
 - Num activities: 2
@@ -275,7 +277,7 @@ Current week summary (today is Wednesday):
 Weekly summary for 2025-03-10 to 2025-03-16:
 ----- Per-day breakdown -----
 --- Monday ---
-Run: Recovery Run
+Run (Easy): Recovery Run
 - Moving time: 00:40:00 (no rest)
 - Distance: 5.0 km
 - Pace: 8:00/km
@@ -283,6 +285,8 @@ Run: Recovery Run
 - Max heart rate: 142 bpm
 - Notes: recovery jog
 
+----- Run intensity -----
+Easy: 1
 ----- Volume aggregation by sport -----
 --- Run ---
 - Num activities: 1


### PR DESCRIPTION
## Summary
- Add `PaceZones` domain type derived from the athlete's best available PB (5K → 10K → Half → Marathon → 1K priority), providing Easy/Marathon/Threshold/Interval pace targets for the LLM to reference in coaching responses
- Add workout classifier that auto-labels each run as Easy/Long Run/Tempo/Interval using HR zones (moving/elapsed ratio for intervals, avg HR fraction for tempo/easy) with pace-zone fallbacks when no HR data is available
- Inject classification labels into `TrainingHistorySection` activity rendering (`Run (Easy): Title`) and add a per-week run intensity distribution block (`----- Run intensity -----\nEasy: 2 | Interval: 1`)
- Add `PaceZonesSection` to the coach context pipeline (silently omitted when no PBs recorded)

Closes #93, #94

## Test plan
- [ ] `uv run pytest coach/ -q --ignore=coach/.venv` — all 338 tests pass
- [ ] `uv run ruff check coach/` — no errors
- [ ] `uv run mypy coach/` — no errors
- [ ] Golden test updated to reflect new activity labels and intensity distribution blocks
- [ ] New builder tests: `test_pace_zones.py` (8 tests), `test_workout_classifier.py` (10 tests)
- [ ] New section tests: 6 additional cases in `test_training_history.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)