### PR TITLE
feat: enrich activities with km splits and pace zone intensity profiles

### DIFF
--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -10,7 +10,7 @@ Phases 1–6 are complete. The app is live at https://coach-production-e0b4.up.r
 
 ## Tier 2 — next (PRDs required before implementation)
 
-- [ ] #106 — **Activity enrichment** (PRD): km splits + HR from Strava detailed API; pace zones derived from PBs; intensity breakdown in coach context
+- [x] #106 — **Activity enrichment**: km splits + HR from Strava detailed API; pace zones derived from PBs; `ActivityIntensityProfile` builder; `ActivityIntensitySection` in coach context
 - [ ] #107 — **Prompt caching**: `cache_control` on static coaching context block (Anthropic); depends on #104
 - [ ] #108 — **Freemium tier** (PRD): system Anthropic key + per-user usage caps + BYOK unlimited; depends on #104 + #107
 

--- a/coach/builders/activity_intensity.py
+++ b/coach/builders/activity_intensity.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+from coach.domain.activity import Activity
+from coach.domain.activity import Split
+from coach.domain.activity import SportType
+from coach.domain.activity_intensity import ActivityIntensityProfile
+from coach.domain.activity_intensity import PaceZone
+from coach.domain.activity_intensity import ZoneDistribution
+from coach.domain.personal_bests import RunningPersonalBestsSummary
+
+_10K_TO_5K_RATIO = 0.93
+
+
+def _pace_str_to_speed_ms(pace_str: str) -> Optional[float]:
+    match = re.match(r'(\d+):(\d+)/km', pace_str)
+    if not match:
+        return None
+    seconds_per_km = int(match.group(1)) * 60 + int(match.group(2))
+    if seconds_per_km <= 0:
+        return None
+    return 1000.0 / seconds_per_km
+
+
+def _resolve_speeds(pb_summary: RunningPersonalBestsSummary) -> Optional[tuple[float, float]]:
+    v5k = _pace_str_to_speed_ms(pb_summary.PB_5K.pace_str) if pb_summary.PB_5K else None
+    v10k = _pace_str_to_speed_ms(pb_summary.PB_10K.pace_str) if pb_summary.PB_10K else None
+
+    if v5k is None and v10k is None:
+        return None
+    if v5k is None:
+        v5k = v10k / _10K_TO_5K_RATIO  # type: ignore[operator]
+    if v10k is None:
+        v10k = v5k * _10K_TO_5K_RATIO
+    if v10k >= v5k:
+        v10k = v5k * _10K_TO_5K_RATIO
+
+    return v5k, v10k
+
+
+def _assign_zone(speed_ms: float, v5k: float, v10k: float) -> PaceZone:
+    if speed_ms >= v5k:
+        return PaceZone.Z5_VO2MAX
+    if speed_ms >= v10k * 0.92:
+        return PaceZone.Z4_THRESHOLD
+    if speed_ms >= v5k * 0.80:
+        return PaceZone.Z3_TEMPO
+    if speed_ms >= v5k * 0.75:
+        return PaceZone.Z2_EASY
+    return PaceZone.Z1_RECOVERY
+
+
+def _build_zone_distribution(splits: list[Split], v5k: float, v10k: float) -> list[ZoneDistribution]:
+    accum: dict[PaceZone, tuple[float, int]] = {}
+
+    for split in splits:
+        if split.average_speed_ms <= 0:
+            continue
+        zone = _assign_zone(split.average_speed_ms, v5k, v10k)
+        prev_dist, prev_time = accum.get(zone, (0.0, 0))
+        accum[zone] = (prev_dist + split.distance_meters, prev_time + split.moving_time_seconds)
+
+    return [ZoneDistribution(zone=zone, distance_meters=dist, time_seconds=time) for zone, (dist, time) in sorted(accum.items(), key=lambda kv: kv[0].value)]
+
+
+def _detect_split(splits: list[Split]) -> Optional[bool]:
+    if len(splits) < 2:
+        return None
+
+    mid = len(splits) // 2
+    first_half = splits[:mid]
+    second_half = splits[mid:]
+
+    first_total_dist = sum(s.distance_meters for s in first_half)
+    second_total_dist = sum(s.distance_meters for s in second_half)
+    if first_total_dist <= 0 or second_total_dist <= 0:
+        return None
+
+    first_speed = sum(s.average_speed_ms * s.distance_meters for s in first_half) / first_total_dist
+    second_speed = sum(s.average_speed_ms * s.distance_meters for s in second_half) / second_total_dist
+
+    diff_ratio = (second_speed - first_speed) / first_speed
+    if abs(diff_ratio) < 0.02:
+        return None
+    return diff_ratio > 0
+
+
+def _compute_hr_drift(splits: list[Split]) -> Optional[float]:
+    splits_with_hr = [s for s in splits if s.average_heartrate is not None]
+    if len(splits_with_hr) < len(splits) * 0.5 or len(splits_with_hr) < 2:
+        return None
+
+    mid = len(splits_with_hr) // 2
+    first_hr = sum(s.average_heartrate for s in splits_with_hr[:mid]) / mid  # type: ignore[misc]
+    second_hr = sum(s.average_heartrate for s in splits_with_hr[mid:]) / len(splits_with_hr[mid:])  # type: ignore[misc]
+
+    return second_hr / first_hr
+
+
+def _build_flags(
+    zone_distribution: list[ZoneDistribution],
+    primary_zone: PaceZone,
+    total_distance: float,
+    is_negative_split: Optional[bool],
+    hr_drift: Optional[float],
+) -> list[str]:
+    flags: list[str] = []
+
+    primary_dist = next((z.distance_meters for z in zone_distribution if z.zone == primary_zone), 0.0)
+    pct = int(round(100 * primary_dist / total_distance)) if total_distance > 0 else 0
+    zone_label = primary_zone.value.split('/')[1].lower()
+    flags.append(f'{primary_zone.value} {zone_label} run ({pct}%)')
+
+    if is_negative_split is True:
+        flags.append('negative split — strong finish')
+    elif is_negative_split is False:
+        flags.append('positive split — faded in second half')
+
+    if hr_drift is not None and hr_drift > 1.05:
+        drift_pct = int(round((hr_drift - 1) * 100))
+        flags.append(f'HR climbed {drift_pct}% across the run')
+
+    return flags
+
+
+def build_activity_intensity_profile(
+    activity: Activity,
+    pb_summary: RunningPersonalBestsSummary,
+) -> Optional[ActivityIntensityProfile]:
+    if activity.sport_type != SportType.RUN:
+        return None
+    if not activity.splits:
+        return None
+
+    speeds = _resolve_speeds(pb_summary)
+    if speeds is None:
+        return None
+
+    v5k, v10k = speeds
+    zone_distribution = _build_zone_distribution(activity.splits, v5k, v10k)
+    if not zone_distribution:
+        return None
+
+    primary_zone = max(zone_distribution, key=lambda z: z.time_seconds).zone
+    total_distance = sum(z.distance_meters for z in zone_distribution)
+    is_negative_split = _detect_split(activity.splits)
+    hr_drift = _compute_hr_drift(activity.splits)
+    flags = _build_flags(zone_distribution, primary_zone, total_distance, is_negative_split, hr_drift)
+
+    return ActivityIntensityProfile(
+        activity_id=activity.id,
+        zone_distribution=zone_distribution,
+        primary_zone=primary_zone,
+        is_negative_split=is_negative_split,
+        hr_drift=hr_drift,
+        flags=flags,
+    )

--- a/coach/builders/tests/test_activity_intensity.py
+++ b/coach/builders/tests/test_activity_intensity.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from coach.builders.activity_intensity import build_activity_intensity_profile
+from coach.domain.activity import Split
+from coach.domain.activity import SportType
+from coach.domain.activity_intensity import PaceZone
+from coach.domain.personal_bests import RunningPersonalBestsSummary
+from coach.tests.utils_for_tests import make_activity
+
+# 5K PB: 20:00 → 4:00/km → v5k = 1000/240 ≈ 4.167 m/s
+# 10K PB: 42:00 → 4:12/km → v10k = 1000/252 ≈ 3.968 m/s
+_PB_WITH_5K_AND_10K = RunningPersonalBestsSummary(
+    PB_1K=None,
+    PB_5K=None,
+    PB_10K=None,
+    PB_15K=None,
+    PB_HALF_MARATHON=None,
+    PB_MARATHON=None,
+)
+
+
+def _make_pb_summary(
+    *,
+    pb_5k_seconds: int | None = None,
+    pb_10k_seconds: int | None = None,
+) -> RunningPersonalBestsSummary:
+    from datetime import date
+
+    from coach.domain.personal_bests import RunningPersonalBest
+
+    def pb(distance_meters: float, seconds: int) -> RunningPersonalBest:
+        spm = seconds / distance_meters
+        km_seconds = spm * 1000
+        minutes = int(km_seconds // 60)
+        secs = int(km_seconds % 60)
+        return RunningPersonalBest(achieved_on=date(2025, 1, 1), pace_str=f'{minutes}:{secs:02d}/km')
+
+    return RunningPersonalBestsSummary(
+        PB_1K=None,
+        PB_5K=pb(5000, pb_5k_seconds) if pb_5k_seconds else None,
+        PB_10K=pb(10000, pb_10k_seconds) if pb_10k_seconds else None,
+        PB_15K=None,
+        PB_HALF_MARATHON=None,
+        PB_MARATHON=None,
+    )
+
+
+def _make_split(speed_ms: float, distance: float = 1000.0, hr: float | None = None) -> Split:
+    moving_time = int(distance / speed_ms)
+    return Split(
+        distance_meters=distance,
+        elapsed_time_seconds=moving_time,
+        moving_time_seconds=moving_time,
+        average_speed_ms=speed_ms,
+        average_heartrate=hr,
+    )
+
+
+class TestBuildActivityIntensityProfileReturnsNone:
+    def test_returns_none_for_non_run(self) -> None:
+        pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+        ride = make_activity(sport_type=SportType.RIDE, splits=[_make_split(5.0)])
+        assert build_activity_intensity_profile(ride, pb_summary) is None
+
+    def test_returns_none_when_no_splits(self) -> None:
+        pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+        run = make_activity()
+        assert run.splits == []
+        assert build_activity_intensity_profile(run, pb_summary) is None
+
+    def test_returns_none_when_no_pbs(self) -> None:
+        run = make_activity(splits=[_make_split(3.0)])
+        pb_summary = _make_pb_summary()
+        assert build_activity_intensity_profile(run, pb_summary) is None
+
+
+class TestZoneAssignment:
+    def setup_method(self) -> None:
+        # 5K: 20:00 (1200s) → 4:00/km → v5k = 4.167 m/s
+        # 10K: 43:00 (2580s) → 4:18/km → v10k = 3.876 m/s
+        self._pb_summary = _make_pb_summary(pb_5k_seconds=1200, pb_10k_seconds=2580)
+
+    def _profile_primary_zone(self, speed_ms: float) -> PaceZone:
+        run = make_activity(splits=[_make_split(speed_ms)])
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        return profile.primary_zone
+
+    def test_faster_than_5k_pace_is_vo2max(self) -> None:
+        # v5k ≈ 4.167, so 4.5 m/s is faster
+        assert self._profile_primary_zone(4.5) == PaceZone.Z5_VO2MAX
+
+    def test_near_10k_pace_is_threshold(self) -> None:
+        # v10k ≈ 3.876, 92% of that = 3.566; speed of 3.7 should be Z4
+        assert self._profile_primary_zone(3.7) == PaceZone.Z4_THRESHOLD
+
+    def test_above_80pct_5k_below_threshold_is_tempo(self) -> None:
+        # 80% of v5k = 3.333; just above should be Z3
+        assert self._profile_primary_zone(3.4) == PaceZone.Z3_TEMPO
+
+    def test_75_to_80_pct_5k_is_easy(self) -> None:
+        # 75-80% of v5k = 3.125-3.333; 3.2 should be Z2
+        assert self._profile_primary_zone(3.2) == PaceZone.Z2_EASY
+
+    def test_below_75_pct_5k_is_recovery(self) -> None:
+        # < 75% of v5k = < 3.125; 2.5 should be Z1
+        assert self._profile_primary_zone(2.5) == PaceZone.Z1_RECOVERY
+
+
+class TestZoneAssignmentWithOnly5kPb:
+    def test_zones_inferred_from_5k_only(self) -> None:
+        pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+        run = make_activity(splits=[_make_split(3.7)])
+        profile = build_activity_intensity_profile(run, pb_summary)
+        assert profile is not None
+        assert profile.primary_zone == PaceZone.Z4_THRESHOLD
+
+
+class TestZoneAssignmentWithOnly10kPb:
+    def test_zones_inferred_from_10k_only(self) -> None:
+        pb_summary = _make_pb_summary(pb_10k_seconds=2580)
+        run = make_activity(splits=[_make_split(2.5)])
+        profile = build_activity_intensity_profile(run, pb_summary)
+        assert profile is not None
+        assert profile.primary_zone == PaceZone.Z1_RECOVERY
+
+
+class TestSplitDetection:
+    def setup_method(self) -> None:
+        self._pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+
+    def test_negative_split_detected_when_second_half_faster(self) -> None:
+        splits = [_make_split(3.0), _make_split(3.0), _make_split(3.5), _make_split(3.5)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.is_negative_split is True
+
+    def test_positive_split_detected_when_second_half_slower(self) -> None:
+        splits = [_make_split(3.5), _make_split(3.5), _make_split(3.0), _make_split(3.0)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.is_negative_split is False
+
+    def test_even_split_returns_none(self) -> None:
+        splits = [_make_split(3.0), _make_split(3.0), _make_split(3.01), _make_split(3.0)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.is_negative_split is None
+
+    def test_single_split_returns_none(self) -> None:
+        run = make_activity(splits=[_make_split(3.0)])
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.is_negative_split is None
+
+
+class TestHrDrift:
+    def setup_method(self) -> None:
+        self._pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+
+    def test_hr_drift_detected_when_second_half_higher(self) -> None:
+        splits = [
+            _make_split(3.0, hr=140.0),
+            _make_split(3.0, hr=142.0),
+            _make_split(3.0, hr=155.0),
+            _make_split(3.0, hr=157.0),
+        ]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.hr_drift is not None
+        assert profile.hr_drift > 1.05
+
+    def test_no_hr_data_returns_none(self) -> None:
+        splits = [_make_split(3.0), _make_split(3.0), _make_split(3.0), _make_split(3.0)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.hr_drift is None
+
+    def test_sparse_hr_coverage_returns_none(self) -> None:
+        splits = [
+            _make_split(3.0, hr=140.0),
+            _make_split(3.0),
+            _make_split(3.0),
+            _make_split(3.0),
+        ]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert profile.hr_drift is None
+
+
+class TestFlags:
+    def setup_method(self) -> None:
+        self._pb_summary = _make_pb_summary(pb_5k_seconds=1200)
+
+    def test_primary_zone_flag_always_present(self) -> None:
+        run = make_activity(splits=[_make_split(3.2)])
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert any('Z2/Easy' in f for f in profile.flags)
+
+    def test_negative_split_flag_present(self) -> None:
+        splits = [_make_split(3.0), _make_split(3.0), _make_split(3.5), _make_split(3.5)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert any('negative split' in f for f in profile.flags)
+
+    def test_positive_split_flag_present(self) -> None:
+        splits = [_make_split(3.5), _make_split(3.5), _make_split(3.0), _make_split(3.0)]
+        run = make_activity(splits=splits)
+        profile = build_activity_intensity_profile(run, self._pb_summary)
+        assert profile is not None
+        assert any('positive split' in f for f in profile.flags)

--- a/coach/domain/activity.py
+++ b/coach/domain/activity.py
@@ -22,6 +22,15 @@ class BestEffort:
     moving_time_seconds: int
 
 
+@dataclass(frozen=True, kw_only=True, slots=True)
+class Split:
+    distance_meters: float
+    elapsed_time_seconds: int
+    moving_time_seconds: int
+    average_speed_ms: float
+    average_heartrate: Optional[float]
+
+
 DISTANCE_SPORT_TYPES = (SportType.RUN, SportType.RIDE, SportType.SWIM, SportType.WALK)
 
 
@@ -55,3 +64,6 @@ class Activity:
 
     # Personal bests
     pbs: list[BestEffort] = field(default_factory=list)
+
+    # Per-km splits from Strava detailed activity (empty for manual/old activities)
+    splits: list[Split] = field(default_factory=list)

--- a/coach/domain/activity_intensity.py
+++ b/coach/domain/activity_intensity.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Optional
+
+
+class PaceZone(StrEnum):
+    Z1_RECOVERY = 'Z1/Recovery'
+    Z2_EASY = 'Z2/Easy'
+    Z3_TEMPO = 'Z3/Tempo'
+    Z4_THRESHOLD = 'Z4/Threshold'
+    Z5_VO2MAX = 'Z5/VO2max'
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ZoneDistribution:
+    zone: PaceZone
+    distance_meters: float
+    time_seconds: int
+
+
+@dataclass(frozen=True, kw_only=True, slots=True)
+class ActivityIntensityProfile:
+    activity_id: int
+    zone_distribution: list[ZoneDistribution]
+    primary_zone: PaceZone
+    is_negative_split: Optional[bool]
+    hr_drift: Optional[float]
+    flags: list[str]

--- a/coach/ingestion/strava/mapper.py
+++ b/coach/ingestion/strava/mapper.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from coach.domain.activity import Activity
 from coach.domain.activity import BestEffort
+from coach.domain.activity import Split
 from coach.domain.activity import SportType
 from coach.utils import parse_utc_datetime
 
@@ -29,12 +30,33 @@ def map_strava_activity(payload: dict[str, Any]) -> Activity:
         is_manual=bool(payload.get('manual', False)),
         is_race=bool(payload.get('workout_type') == 1),
         pbs=map_pbs(payload.get('best_efforts')),
+        splits=map_splits(payload.get('splits_metric')),
     )
 
 
 def _map_sport_type(payload: dict[str, str]) -> SportType:
     raw = payload.get('sport_type') or payload.get('type') or SportType.OTHER
     return SportType(raw) if raw in SportType._value2member_map_ else SportType.OTHER
+
+
+def map_splits(splits_metric: Optional[list[dict[str, Any]]]) -> list[Split]:
+    if not splits_metric:
+        return []
+    result = []
+    for s in splits_metric:
+        distance = s.get('distance', 0.0)
+        if not distance or distance <= 0:
+            continue
+        result.append(
+            Split(
+                distance_meters=float(distance),
+                elapsed_time_seconds=int(s.get('elapsed_time', 0)),
+                moving_time_seconds=int(s.get('moving_time', 0)),
+                average_speed_ms=float(s.get('average_speed', 0.0)),
+                average_heartrate=s.get('average_heartrate'),
+            ),
+        )
+    return result
 
 
 def map_pbs(best_efforts: Optional[list[dict[str, Any]]]) -> list[BestEffort]:

--- a/coach/ingestion/strava/tests/test_mapper.py
+++ b/coach/ingestion/strava/tests/test_mapper.py
@@ -3,9 +3,11 @@ from datetime import datetime
 from typing import Any
 
 from coach.domain.activity import BestEffort
+from coach.domain.activity import Split
 from coach.domain.activity import SportType
 from coach.ingestion.strava.mapper import map_activities
 from coach.ingestion.strava.mapper import map_pbs
+from coach.ingestion.strava.mapper import map_splits
 from coach.ingestion.strava.mapper import map_strava_activity
 
 
@@ -125,6 +127,53 @@ class TestStravaMapperMapPbs:
             ],
         )
         assert map_strava_activity(payload).pbs == [BestEffort(name='5K', moving_time_seconds=1200)]
+
+
+class TestStravaMapperMapSplits:
+    def test_returns_empty_when_none(self) -> None:
+        assert map_splits(None) == []
+
+    def test_returns_empty_when_empty_list(self) -> None:
+        assert map_splits([]) == []
+
+    def test_maps_split_fields(self) -> None:
+        raw = [{'distance': 1000.0, 'elapsed_time': 355, 'moving_time': 350, 'average_speed': 2.86, 'average_heartrate': 155.0}]
+        result = map_splits(raw)
+        assert len(result) == 1
+        assert result[0] == Split(
+            distance_meters=1000.0,
+            elapsed_time_seconds=355,
+            moving_time_seconds=350,
+            average_speed_ms=2.86,
+            average_heartrate=155.0,
+        )
+
+    def test_skips_zero_distance_splits(self) -> None:
+        raw = [
+            {'distance': 0.0, 'elapsed_time': 5, 'moving_time': 5, 'average_speed': 2.5, 'average_heartrate': None},
+            {'distance': 1000.0, 'elapsed_time': 350, 'moving_time': 350, 'average_speed': 2.86, 'average_heartrate': None},
+        ]
+        result = map_splits(raw)
+        assert len(result) == 1
+
+    def test_hr_optional(self) -> None:
+        raw = [{'distance': 1000.0, 'elapsed_time': 350, 'moving_time': 350, 'average_speed': 2.86}]
+        result = map_splits(raw)
+        assert result[0].average_heartrate is None
+
+    def test_splits_present_on_mapped_activity(self) -> None:
+        payload = _base_payload(
+            splits_metric=[
+                {'distance': 1000.0, 'elapsed_time': 350, 'moving_time': 350, 'average_speed': 2.86, 'average_heartrate': 155.0},
+            ],
+        )
+        activity = map_strava_activity(payload)
+        assert len(activity.splits) == 1
+        assert activity.splits[0].distance_meters == 1000.0
+
+    def test_no_splits_metric_gives_empty_splits(self) -> None:
+        activity = map_strava_activity(_base_payload())
+        assert activity.splits == []
 
 
 class TestStravaMapperMapActivities:

--- a/coach/persistence/serialization.py
+++ b/coach/persistence/serialization.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from coach.domain.activity import Activity
 from coach.domain.activity import BestEffort
+from coach.domain.activity import Split
 from coach.domain.activity import SportType
 from coach.domain.goals import DistanceActivityTrainingGoal
 from coach.domain.goals import Priority
@@ -74,6 +75,7 @@ def deserialize_goal(raw: dict[str, Any]) -> TrainingGoal:
 
 def deserialize_activity(serialized: dict[str, Any]) -> Activity:
     pbs = [BestEffort(name=pb['name'], moving_time_seconds=pb['moving_time_seconds']) for pb in serialized['pbs']]
+    splits = [Split(**s) for s in serialized.get('splits', [])]
 
     return Activity(
         id=serialized['id'],
@@ -91,4 +93,5 @@ def deserialize_activity(serialized: dict[str, Any]) -> Activity:
         is_manual=bool(serialized['is_manual']),
         is_race=bool(serialized['is_race']),
         pbs=pbs,
+        splits=splits,
     )

--- a/coach/persistence/tests/test_serialization.py
+++ b/coach/persistence/tests/test_serialization.py
@@ -28,6 +28,7 @@ def test_serialize_activity() -> None:
         'is_manual': SAMPLE_RUN.is_manual,
         'is_race': SAMPLE_RUN.is_race,
         'pbs': [{'name': '1K', 'moving_time_seconds': 120}],
+        'splits': [],
     }
 
 

--- a/coach/reasoning/coach/coach.py
+++ b/coach/reasoning/coach/coach.py
@@ -40,6 +40,7 @@ class Coach(Assistant):
             profile=profile,
             recent_training_history=recent_training_history,
             pb_summary=pb_summary,
+            activities=activities,
         )
 
     def _user_system_prompt(self) -> Optional[str]:

--- a/coach/reasoning/coach/context.py
+++ b/coach/reasoning/coach/context.py
@@ -1,10 +1,16 @@
+from datetime import datetime
+from datetime import timedelta
 from typing import Optional
 
+from coach.builders.activity_intensity import build_activity_intensity_profile
 from coach.builders.training_phase import detect_training_phase
 from coach.builders.training_trends import build_training_trends
+from coach.domain.activity import Activity
+from coach.domain.activity_intensity import ActivityIntensityProfile
 from coach.domain.personal_bests import RunningPersonalBestsSummary
 from coach.domain.profile import UserProfile
 from coach.domain.training_summaries import RecentTrainingHistory
+from coach.reasoning.coach.sections import ActivityIntensitySection
 from coach.reasoning.coach.sections import ContextSection
 from coach.reasoning.coach.sections import GoalStateSection
 from coach.reasoning.coach.sections import PersonalBestsSection
@@ -14,18 +20,38 @@ from coach.reasoning.coach.sections import TrainingPhaseSection
 from coach.reasoning.coach.sections import TrainingTrendsSection
 from coach.reasoning.coach.sections.utils import combine_sections
 
+_INTENSITY_WINDOW_DAYS = 14
+
+
+def _collect_intensity_profiles(
+    activities: list[Activity],
+    pb_summary: RunningPersonalBestsSummary,
+    generated_at: datetime,
+) -> list[tuple[datetime, str, ActivityIntensityProfile]]:
+    cutoff = generated_at - timedelta(days=_INTENSITY_WINDOW_DAYS)
+    result: list[tuple[datetime, str, ActivityIntensityProfile]] = []
+    for activity in activities:
+        if activity.start_time_utc < cutoff:
+            continue
+        profile = build_activity_intensity_profile(activity, pb_summary)
+        if profile is not None:
+            result.append((activity.start_time_utc, activity.name or '', profile))
+    return sorted(result, key=lambda t: t[0])
+
 
 def build_coach_context(
     *,
     profile: Optional[UserProfile],
     recent_training_history: RecentTrainingHistory,
     pb_summary: RunningPersonalBestsSummary,
+    activities: list[Activity],
 ) -> Optional[str]:
     training_trends = build_training_trends(recent_training_history)
     training_phase = detect_training_phase(
         profile.goals if profile and profile.goals else (),
         recent_training_history.generated_at,
     )
+    intensity_profiles = _collect_intensity_profiles(activities, pb_summary, recent_training_history.generated_at)
 
     sections: list[ContextSection] = []
     sections.append(TrainingPhaseSection(training_phase))
@@ -34,6 +60,7 @@ def build_coach_context(
         sections.append(GoalStateSection(profile, pb_summary))
     sections.append(TrainingTrendsSection(training_trends))
     sections.append(TrainingHistorySection(recent_training_history))
+    sections.append(ActivityIntensitySection(intensity_profiles))
     sections.append(PersonalBestsSection(pb_summary))
 
     rendered_pairs = [(s.header, s.render()) for s in sections]

--- a/coach/reasoning/coach/sections/__init__.py
+++ b/coach/reasoning/coach/sections/__init__.py
@@ -1,3 +1,4 @@
+from coach.reasoning.coach.sections.activity_intensity import ActivityIntensitySection
 from coach.reasoning.coach.sections.base import ContextSection
 from coach.reasoning.coach.sections.goal_state import GoalStateSection
 from coach.reasoning.coach.sections.personal_bests import PersonalBestsSection
@@ -7,6 +8,7 @@ from coach.reasoning.coach.sections.training_phase import TrainingPhaseSection
 from coach.reasoning.coach.sections.training_trends import TrainingTrendsSection
 
 __all__ = [
+    'ActivityIntensitySection',
     'ContextSection',
     'GoalStateSection',
     'PersonalBestsSection',

--- a/coach/reasoning/coach/sections/activity_intensity.py
+++ b/coach/reasoning/coach/sections/activity_intensity.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from coach.domain.activity_intensity import ActivityIntensityProfile
+from coach.domain.activity_intensity import ZoneDistribution
+from coach.reasoning.coach.sections.base import ContextSection
+
+
+def _render_zone_breakdown(zone_distribution: list[ZoneDistribution], total_distance: float) -> str:
+    parts = []
+    for zd in zone_distribution:
+        pct = int(round(100 * zd.distance_meters / total_distance)) if total_distance > 0 else 0
+        parts.append(f'{zd.zone.value} {pct}%')
+    return ', '.join(parts)
+
+
+class ActivityIntensitySection(ContextSection):
+    def __init__(self, profiles: list[tuple[datetime, str, ActivityIntensityProfile]]) -> None:
+        self._profiles = profiles
+
+    @property
+    def header(self) -> str:
+        return 'Activity intensity breakdown:'
+
+    def render(self) -> Optional[str]:
+        if not self._profiles:
+            return None
+
+        lines: list[str] = ['-' * 40, 'Pace zone breakdown for recent runs (derived from PBs):']
+        for start_time, name, profile in self._profiles:
+            total_distance = sum(z.distance_meters for z in profile.zone_distribution)
+            zone_str = _render_zone_breakdown(profile.zone_distribution, total_distance)
+            date_str = start_time.strftime('%a %d %b')
+            activity_label = name or 'Run'
+            line = f'{date_str} — {activity_label}: {zone_str}'
+            if profile.flags[1:]:
+                line += ' | ' + '; '.join(profile.flags[1:])
+            lines.append(line)
+        lines.append('-' * 40)
+        return '\n'.join(lines)

--- a/coach/reasoning/coach/sections/tests/test_activity_intensity.py
+++ b/coach/reasoning/coach/sections/tests/test_activity_intensity.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+
+from coach.domain.activity_intensity import ActivityIntensityProfile
+from coach.domain.activity_intensity import PaceZone
+from coach.domain.activity_intensity import ZoneDistribution
+from coach.reasoning.coach.sections.activity_intensity import ActivityIntensitySection
+
+
+def _make_profile(
+    *,
+    activity_id: int = 1,
+    zones: list[ZoneDistribution] | None = None,
+    primary_zone: PaceZone = PaceZone.Z2_EASY,
+    is_negative_split: bool | None = None,
+    hr_drift: float | None = None,
+    flags: list[str] | None = None,
+) -> ActivityIntensityProfile:
+    if zones is None:
+        zones = [ZoneDistribution(zone=PaceZone.Z2_EASY, distance_meters=8000.0, time_seconds=2880)]
+    if flags is None:
+        flags = ['Z2/Easy easy run (100%)']
+    return ActivityIntensityProfile(
+        activity_id=activity_id,
+        zone_distribution=zones,
+        primary_zone=primary_zone,
+        is_negative_split=is_negative_split,
+        hr_drift=hr_drift,
+        flags=flags,
+    )
+
+
+class TestActivityIntensitySectionRendersNone:
+    def test_renders_none_when_no_profiles(self) -> None:
+        section = ActivityIntensitySection([])
+        assert section.render() is None
+
+
+class TestActivityIntensitySectionRendersProfiles:
+    def setup_method(self) -> None:
+        start_time = datetime(2025, 5, 12, 7, 0, 0, tzinfo=UTC)
+        profile = _make_profile()
+        self._section = ActivityIntensitySection([(start_time, 'Morning Run', profile)])
+        self._result = self._section.render()
+
+    def test_render_is_not_none(self) -> None:
+        assert self._result is not None
+
+    def test_activity_name_in_output(self) -> None:
+        assert 'Morning Run' in self._result  # type: ignore[operator]
+
+    def test_zone_percentage_in_output(self) -> None:
+        assert 'Z2/Easy' in self._result  # type: ignore[operator]
+        assert '100%' in self._result  # type: ignore[operator]
+
+    def test_date_formatted_correctly(self) -> None:
+        assert 'Mon 12 May' in self._result  # type: ignore[operator]
+
+
+class TestActivityIntensitySectionWithFlags:
+    def test_split_flag_appears_after_pipe(self) -> None:
+        profile = _make_profile(
+            is_negative_split=False,
+            flags=['Z2/Easy easy run (80%)', 'positive split — faded in second half'],
+        )
+        section = ActivityIntensitySection([(datetime(2025, 5, 12, tzinfo=UTC), 'Easy Run', profile)])
+        result = section.render()
+        assert result is not None
+        assert 'positive split' in result
+
+    def test_no_extra_pipe_when_only_primary_flag(self) -> None:
+        profile = _make_profile(flags=['Z2/Easy easy run (100%)'])
+        section = ActivityIntensitySection([(datetime(2025, 5, 12, tzinfo=UTC), 'Easy Run', profile)])
+        result = section.render()
+        assert result is not None
+        assert '|' not in result
+
+    def test_multiple_activities_all_appear(self) -> None:
+        p1 = _make_profile(activity_id=1)
+        p2 = _make_profile(activity_id=2)
+        profiles = [
+            (datetime(2025, 5, 12, tzinfo=UTC), 'Run A', p1),
+            (datetime(2025, 5, 14, tzinfo=UTC), 'Run B', p2),
+        ]
+        section = ActivityIntensitySection(profiles)
+        result = section.render()
+        assert result is not None
+        assert 'Run A' in result
+        assert 'Run B' in result
+
+    def test_header_is_correct(self) -> None:
+        section = ActivityIntensitySection([])
+        assert section.header == 'Activity intensity breakdown:'

--- a/coach/reasoning/coach/tests/test_context.py
+++ b/coach/reasoning/coach/tests/test_context.py
@@ -30,6 +30,7 @@ def _build_context(
         profile=profile,
         recent_training_history=build_recent_training_history(activities=acts, generated_at=generated_at, num_history_weeks=num_history_weeks),
         pb_summary=build_running_personal_bests_summary(activities=acts),
+        activities=acts,
     )
 
 

--- a/coach/tests/utils_for_tests.py
+++ b/coach/tests/utils_for_tests.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from coach.domain.activity import Activity
 from coach.domain.activity import BestEffort
+from coach.domain.activity import Split
 from coach.domain.activity import SportType
 
 _DEFAULT_START = datetime(2025, 1, 1, tzinfo=UTC)
@@ -15,6 +16,7 @@ def make_activity(
     sport_type: SportType = SportType.RUN,
     start_time_utc: datetime = _DEFAULT_START,
     pbs: Optional[list[BestEffort]] = None,
+    splits: Optional[list[Split]] = None,
 ) -> Activity:
     return Activity(
         id=id,
@@ -25,6 +27,7 @@ def make_activity(
         is_manual=False,
         is_race=False,
         pbs=pbs or [],
+        splits=splits or [],
     )
 
 

--- a/supabase/migrations/20260516_add_splits_column.sql
+++ b/supabase/migrations/20260516_add_splits_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activities ADD COLUMN IF NOT EXISTS splits JSONB NOT NULL DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary

- Adds `Split` domain type and `splits` field to `Activity`; mapper extracts `splits_metric` from the Strava detailed activity response (already fetched at sync time — zero extra API calls)
- New `ActivityIntensityProfile` domain type and `build_activity_intensity_profile` builder: derives Z1–Z5 pace zones from the user's 5K/10K PBs (no user input required), detects positive/negative splits, and computes HR drift across the run
- New `ActivityIntensitySection` added to coach context: renders a compact per-activity zone breakdown for the last 14 days so the LLM can answer intensity questions with real data
- DB migration: `supabase/migrations/20260516_add_splits_column.sql` adds a `splits JSONB` column to the activities table

## Test plan

- [ ] `uv run pytest` — all 377 tests pass
- [ ] `uv run ruff check . && ruff format .` — clean
- [ ] `uv run mypy .` — clean
- [ ] Apply DB migration on production Supabase instance
- [ ] Trigger a Strava webhook activity-create event and verify splits are stored in the `splits` column

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)