### PR TITLE
docs: clarify Strava data used for inference only, not training (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,11 +215,12 @@ Coach requests **read-only** permission (`activity:read_all`). It cannot create,
 
 Your Strava activity data is used **solely** to provide coaching context within Coach. It is not sold, shared with third parties, or used for advertising. Specifically:
 
-- Activity data is passed to the AI model you have configured (e.g. OpenAI, Google Gemini, Anthropic Claude) in order to generate coaching responses. By using Coach you should be aware that this data leaves Coach and is processed by that third-party provider under their own terms of service and privacy policy.
+- Activity data is passed to the AI model you have configured (e.g. OpenAI, Google Gemini, Anthropic Claude) **only to generate coaching responses (inference)** — never to train, fine-tune, or otherwise build AI or machine-learning models. By using Coach you should be aware that this data leaves Coach and is processed by that third-party provider under their own terms of service and privacy policy.
+- **The major providers do not train their models on data sent through their paid APIs.** Both [OpenAI](https://openai.com/enterprise-privacy/) and [Anthropic](https://privacy.anthropic.com/en/articles/7996868-is-my-data-used-for-model-training) state that inputs and outputs submitted via their APIs are not used for model training by default. Coach delegates to each provider's own data-usage policy — review the policy of whichever provider and API key you choose to supply.
 - Activity data is not shared with any other third party.
 - Activity data is not used to train models, build profiles for advertising, or for any purpose other than generating your coaching responses.
 
-This use of Strava data is in line with the [Strava API Agreement](https://www.strava.com/legal/api).
+This use of Strava data is in line with the [Strava API Agreement](https://www.strava.com/legal/api), including its restriction on using athlete data to train artificial-intelligence or machine-learning models.
 
 ### What happens when you disconnect Strava
 


### PR DESCRIPTION
## Summary

Makes Coach's compliance with Strava's API Agreement explicit in the Data & Privacy section: Strava activity data is sent to the configured LLM provider **for inference only** (coaching responses), never to train AI/ML models — which is what Strava's updated agreement prohibits.

- States the inference-only / no-training position directly on the provider bullet.
- Adds a bullet delegating to the providers' own data-usage policies, noting both [OpenAI](https://openai.com/enterprise-privacy/) and [Anthropic](https://privacy.anthropic.com/en/articles/7996868-is-my-data-used-for-model-training) do not train on data submitted via their **paid APIs** by default, and recommending users review the policy for the key/tier they supply.
- Ties the section back to the Strava API Agreement's AI/ML training restriction.

## Test plan

- [ ] Render `README.md` and confirm the Data & Privacy → "How your Strava data is used" section reads clearly and both provider links resolve.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)